### PR TITLE
Add hash history to fix 404 at gh_pages

### DIFF
--- a/src/helpers/history.js
+++ b/src/helpers/history.js
@@ -1,3 +1,3 @@
-import { createBrowserHistory } from 'history';
+import { createHashHistory } from 'history';
 
-export const history = createBrowserHistory();
+export const history = createHashHistory();


### PR DESCRIPTION
The page is rendered at server side (react), but first, gh_pages try to route in the repository directory, leading to 404.
This small fix try to solve this little bug. The # leads to index.js, then the server side (react) can route correctly.

[font](https://stackoverflow.com/questions/46056414/getting-404-for-links-with-create-react-app-deployed-to-github-pages)

