### PR TITLE
blank space after 'Editar'

### DIFF
--- a/src/components/modal/DocumentModal.js
+++ b/src/components/modal/DocumentModal.js
@@ -74,7 +74,7 @@ const DocumentModal = ({
               </Row>
               <p className="text-center">
                 A prova não tem questões. Para adicionar questões, entre na opção
-                <strong>Editar</strong>
+                <strong> Editar</strong>
               </p>
             </div>
           )

--- a/src/services/documentService.js
+++ b/src/services/documentService.js
@@ -239,7 +239,7 @@ function downloadDocument(props, idDocument) {
     },
   };
 
-  const headerParameter = (props.headerId ? `&header=${props.headerId}` : '');
+  const headerParameter = (props.headerId && props.headerId !== 'NaN' ? `&header=${props.headerId}` : '');
   
   if (props.answer === 'with') {
     return fetch(`${apiUrl}/documents/${idDocument}/generate_list/?answers=True${headerParameter}`, requestOptions);


### PR DESCRIPTION
**To be tested**

- Enter to _'Minhas Provas_', clicks on a document without questions , a new message in the modal is "A prova não tem questões. Para adicionar questões, entre na opção Editar"
- Export the same document without header (sem cabeçalho) twice, any error will be shown in console. Problem was that 'sem cabeçalho' option has value 'NaN' but documentService.js didnt recognize it.