### PR TITLE
after click on card's filter, history.replace is called before addFilter

### DIFF
--- a/src/containers/QuestionBasePageContainer.js
+++ b/src/containers/QuestionBasePageContainer.js
@@ -28,16 +28,16 @@ const toggleSelectedDifficultyFilter = (difficultyType, value) => {
   return value
     ? addSelectedDifficultyFilter(difficultyType) : removeSelectedDifficultyFilter(difficultyType);
 };
-const toggleSelectedSourceFilter = (idSource, value) => {
+const toggleSelectedSourceFilter = (idSource, nameSource = 'default', value) => {
   history.replace('/question-base/1');
   return value
-    ? addSelectedSourceFilter(idSource) : removeSelectedSourceFilter(idSource);
+    ? addSelectedSourceFilter(idSource, nameSource) : removeSelectedSourceFilter(idSource);
 };
 
-const toggleSelectedYearFilter = (idYear, value) => {
+const toggleSelectedYearFilter = (idYear, nameYear = 'default', value) => {
   history.replace('/question-base/1');
   return value
-    ? addSelectedYearFilter(idYear) : removeSelectedYearFilter(idYear);
+    ? addSelectedYearFilter(idYear, nameYear) : removeSelectedYearFilter(idYear);
 };
 
 const mapStateToProps = state => ({
@@ -55,10 +55,11 @@ const mapDispatchToProps = dispatch => ({
   listQuestions: (page, filter) => dispatch(listQuestions(page, filter)),
   toggleModal: (modal, idQuestion) => dispatch(toggleModal(modal, idQuestion)),
   addSelectedQuestion: (idDocument, idQuestion, order) => dispatch(addSelectedQuestion(idDocument, idQuestion, order)),
-  addSelectedDisciplineFilter: idDiscipline => dispatch(addSelectedDisciplineFilter(idDiscipline)),
-  addSelectedTeachingLevelFilter: idTeachingLevel => dispatch(addSelectedTeachingLevelFilter(idTeachingLevel)),
-  addSelectedSourceFilter: (idSource, nameSource) => dispatch(addSelectedSourceFilter(idSource, nameSource)),
-  addSelectedYearFilter: (idYear, nameYear) => dispatch(addSelectedYearFilter(idYear, nameYear)),
+
+  addSelectedDisciplineFilter: idDiscipline => dispatch(toggleSelectedDisciplineFilter(idDiscipline, true)),
+  addSelectedTeachingLevelFilter: idTeachingLevel => dispatch(toggleSelectedTeachingLevelFilter(idTeachingLevel, true)),
+  addSelectedSourceFilter: (idSource, nameSource) => dispatch(toggleSelectedSourceFilter(idSource, nameSource, true)),
+  addSelectedYearFilter: (idYear, nameYear) => dispatch(toggleSelectedYearFilter(idYear, nameYear, true)),
 
   toggleSelectedDisciplineFilter: (idDiscipline, value) => dispatch(toggleSelectedDisciplineFilter(idDiscipline, value)),
   toggleSelectedTeachingLevelFilter: (idTeachingLevel, value) => dispatch(toggleSelectedTeachingLevelFilter(idTeachingLevel, value)),

--- a/src/containers/QuestionBasePageContainer.js
+++ b/src/containers/QuestionBasePageContainer.js
@@ -28,13 +28,13 @@ const toggleSelectedDifficultyFilter = (difficultyType, value) => {
   return value
     ? addSelectedDifficultyFilter(difficultyType) : removeSelectedDifficultyFilter(difficultyType);
 };
-const toggleSelectedSourceFilter = (idSource, nameSource = 'default', value) => {
+const toggleSelectedSourceFilter = (idSource, value, nameSource = 'default') => {
   history.replace('/question-base/1');
   return value
     ? addSelectedSourceFilter(idSource, nameSource) : removeSelectedSourceFilter(idSource);
 };
 
-const toggleSelectedYearFilter = (idYear, nameYear = 'default', value) => {
+const toggleSelectedYearFilter = (idYear, value, nameYear = 'default') => {
   history.replace('/question-base/1');
   return value
     ? addSelectedYearFilter(idYear, nameYear) : removeSelectedYearFilter(idYear);
@@ -58,8 +58,8 @@ const mapDispatchToProps = dispatch => ({
 
   addSelectedDisciplineFilter: idDiscipline => dispatch(toggleSelectedDisciplineFilter(idDiscipline, true)),
   addSelectedTeachingLevelFilter: idTeachingLevel => dispatch(toggleSelectedTeachingLevelFilter(idTeachingLevel, true)),
-  addSelectedSourceFilter: (idSource, nameSource) => dispatch(toggleSelectedSourceFilter(idSource, nameSource, true)),
-  addSelectedYearFilter: (idYear, nameYear) => dispatch(toggleSelectedYearFilter(idYear, nameYear, true)),
+  addSelectedSourceFilter: (idSource, nameSource) => dispatch(toggleSelectedSourceFilter(idSource, true, nameSource)),
+  addSelectedYearFilter: (idYear, nameYear) => dispatch(toggleSelectedYearFilter(idYear, true, nameYear)),
 
   toggleSelectedDisciplineFilter: (idDiscipline, value) => dispatch(toggleSelectedDisciplineFilter(idDiscipline, value)),
   toggleSelectedTeachingLevelFilter: (idTeachingLevel, value) => dispatch(toggleSelectedTeachingLevelFilter(idTeachingLevel, value)),


### PR DESCRIPTION
**Situation:**
User filters questions from any page of Question Base. 
If search's results can be shown in less pages than the selected page by user, the following error occurs:
GET http://localhost:8000/questions/?page=4&disciplines=9&&&sources=PUC-GO& 404 (Not Found)

**For example:**
- The Question Base Page has 10 pages
-User clicks any filter of any card from page 4
- However, the new results can be show in 2 pages only.
- Error mentioned above happens.
