### PR TITLE
after changing document, user must continue being in current page

### DIFF
--- a/src/containers/DocumentInfoSidebarContainer.js
+++ b/src/containers/DocumentInfoSidebarContainer.js
@@ -17,7 +17,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   listMyLastDocuments: (page, orderField, order) => dispatch(listMyLastDocuments(page, orderField, order)),
-  switchActiveDocument: doc => dispatch(switchActiveDocument(doc, true)),
+  switchActiveDocument: doc => dispatch(switchActiveDocument(doc, false)),
   fetchPreviewDocument: props => dispatch(fetchPreviewDocument(props)),
 
   hideModal: () => dispatch(hideModal()),


### PR DESCRIPTION
Fix for test # 129
[Paula] Quando estou em uma questão (tela de questão) e troco de prova pelo menu no header "trocar prova" , ao invés de manter a tela de questão, estou sendo direcionada para a tela de edição de prova (da nova prova selecionada) e perco a questão - não consigo saber qual era a questão que eu queria adicionar. 