### PR TITLE
Fix/classifyurl ownernoteditor

### DIFF
--- a/src/actions/questionAction.js
+++ b/src/actions/questionAction.js
@@ -90,7 +90,8 @@ export const fetchQuestion = (id) => {
               });
             }
           });
-          // allTopics.push({});
+          // validation for adding empty topic line
+          if (allTopics.length === 0) allTopics.push({});
 
           const alternatives = activeQuestion.alternatives.map(alternative => ({
             id: alternative.id,

--- a/src/actions/questionAction.js
+++ b/src/actions/questionAction.js
@@ -90,7 +90,7 @@ export const fetchQuestion = (id) => {
               });
             }
           });
-          allTopics.push({});
+          // allTopics.push({});
 
           const alternatives = activeQuestion.alternatives.map(alternative => ({
             id: alternative.id,
@@ -193,7 +193,7 @@ export const classifyQuestion = (props) => {
             });
           }
         });
-        allTopics.push({});
+        // allTopics.push({});
 
         const newLearningObjectList = activeQuestion.learning_objects.map(lobj => ({
           id: lobj.id,
@@ -252,7 +252,7 @@ export const updateQuestion = (props) => {
             });
           }
         });
-        allTopics.push({});
+        // allTopics.push({});
 
         const newLearningObjectList = activeQuestion.learning_objects.map(lobj => ({
           id: lobj.id,

--- a/src/components/sidebar/SidebarFilters.js
+++ b/src/components/sidebar/SidebarFilters.js
@@ -32,7 +32,7 @@ class SidebarFilters extends Component {
     } = this.props;
 
     if (isFetchingDisciplineFilters || isFetchingTeachingLevelFilters || isFetchingSourceFilters || isFetchingYearFilters
-      ) {
+    ) {
       return (
         <ListGroup className="question-all-filters">
           <h6>

--- a/src/components/sidebar/SidebarFilters.js
+++ b/src/components/sidebar/SidebarFilters.js
@@ -28,6 +28,7 @@ class SidebarFilters extends Component {
       toggleSelectedSourceFilter, toggleSelectedYearFilter,
       filter,
       clearFilters,
+      onlyMyQuestions,
     } = this.props;
 
     if (isFetchingDisciplineFilters || isFetchingTeachingLevelFilters || isFetchingSourceFilters || isFetchingYearFilters
@@ -71,7 +72,7 @@ class SidebarFilters extends Component {
         </h6>
         {filter.disciplinesSelected.length > 0 || filter.teachingLevelsSelected.length > 0
           || filter.difficultiesSelected.length > 0 || filter.sourcesSelected.length > 0
-          || filter.yearsSelected.length > 0
+          || filter.yearsSelected.length > 0 || onlyMyQuestions
           ? (
             <div className="l-question-all-filters__clear-button">
               <Button className="l-question-all-filters__clear-button--btn" onClick={clearFilters} disabled={isFetchingQuestions}>

--- a/src/containers/FilterContainer.js
+++ b/src/containers/FilterContainer.js
@@ -27,7 +27,7 @@ const mapStateToProps = state => ({
   filter: state.filter,
   questionPage: state.question.questionPage,
   currentPage: state.question.currentPage,
-
+  onlyMyQuestions: state.filter.onlyMyQuestions,
 });
 
 const toggleSelectedDisciplineFilter = (idDiscipline, value) => {

--- a/src/containers/MyQuestionEditPageContainer.js
+++ b/src/containers/MyQuestionEditPageContainer.js
@@ -32,12 +32,6 @@ const mapDispatchToProps = dispatch => ({
   listTeachingLevelFilters: param => dispatch(listTeachingLevelFilters(param)),
   listSourceFilters: param => dispatch(listSourceFilters(param)),
   listTopics: param => dispatch(listTopics(param)),
-  prepareForm: () => {
-    dispatch(initialize('edit-question', {
-      topics: [{}],
-      alternatives: [{}, {}, {}],
-    }));
-  },
 
   onSubmit: (values, d, props) => {
     const errors = [];

--- a/src/containers/MyQuestionEditPageContainer.js
+++ b/src/containers/MyQuestionEditPageContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import {
-  reduxForm, formValueSelector, SubmissionError, initialize,
+  reduxForm, formValueSelector, SubmissionError,
 } from 'redux-form';
 import MyQuestionEditPage from 'pages/Question/MyQuestionEditPage';
 import { fetchQuestion, updateQuestion } from 'actions/questionAction';

--- a/src/containers/QuestionEditPageContainer.js
+++ b/src/containers/QuestionEditPageContainer.js
@@ -9,6 +9,8 @@ import { addSelectedQuestion, removeSelectedQuestion } from 'actions/documentAct
 
 const mapStateToProps = (state) => {
   const selector = formValueSelector('classify-question');
+  const { user } = state.session.session;
+
   return ({
     topics: selector(state, 'topics'),
     isFetching: state.question.isFetching,
@@ -17,6 +19,7 @@ const mapStateToProps = (state) => {
     activeDocument: state.document.activeDocument,
     topicsList: state.topic.topics,
     role: state.session.session.user.groups,
+    userId: user.id,
   });
 };
 

--- a/src/pages/Question/MyQuestionEditPage.js
+++ b/src/pages/Question/MyQuestionEditPage.js
@@ -432,8 +432,7 @@ class MyQuestionEditPage extends Component {
     listSourceFilters();
     const { fetchQuestion, match } = this.props;
     fetchQuestion(match.params.id);
-
-    prepareForm();
+    // prepareForm();
   }
 
     getListTopics = (e, newValue) => {

--- a/src/pages/Question/MyQuestionEditPage.js
+++ b/src/pages/Question/MyQuestionEditPage.js
@@ -425,7 +425,7 @@ const renderTopics = ({
 class MyQuestionEditPage extends Component {
   componentDidMount() {
     const {
-      listDisciplineFilters, listTeachingLevelFilters, listSourceFilters, prepareForm,
+      listDisciplineFilters, listTeachingLevelFilters, listSourceFilters,
     } = this.props;
     listDisciplineFilters();
     listTeachingLevelFilters();

--- a/src/pages/Question/QuestionEditPage.js
+++ b/src/pages/Question/QuestionEditPage.js
@@ -277,9 +277,12 @@ class QuestionEditPage extends Component {
 
   render() {
     const {
-      activeQuestion, isFetching, error, activeDocument, handleSubmit, topicsList, topics, pristine,
+      activeQuestion, userId, isFetching, error, activeDocument, handleSubmit, topicsList, topics, pristine,
       role,
     } = this.props;
+
+    const authorPK = activeQuestion.author ? activeQuestion.author.pk : 'Anônimo';
+
 
     const {
       alternatives, statement, resolution,
@@ -317,7 +320,7 @@ class QuestionEditPage extends Component {
       );
     }
 
-    if (!role.includes('Editores')) {
+    if (!role.includes('Editores') && (authorPK !== userId)) {
       return (
         <HomeUserPage>
           <Alert color="danger">


### PR DESCRIPTION
- Deve permitir usar a URL diretamente (/classify-question/{id}) para classificar quando for o dono da questão e pode ser ou não EDITOR.
- o botão de "limpar todos os filtros" do sidebar deve aparecer inclusive quando o único filtro selecionado for o "pesquisar em minhas questões"
- Entrar no "edit-question" e "classify-question", se a questão já possui pelo menos UM tópico, não é mostrada uma linha vazía de tópicos. Após de apertar o botão "salvar" NÃO aparece tambem a linha vazia. 