### PR TITLE
Feature/toolbar fixed

### DIFF
--- a/src/assets/scss/components/question/_Question.scss
+++ b/src/assets/scss/components/question/_Question.scss
@@ -43,10 +43,47 @@
 //Question Page where c-question is the main container
 .c-question {
     // class for question's header options for all pages related to question
+
     &__row-header-options {
-      background: $color-ma-green-light !important;
-      border-radius: 5px;
-      padding: 10px 0px;
+      background: #838d96 !important;
+      padding: 0.6rem 1rem;
+      box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.15);
+      transition: all 0.3s ease;
+  
+      .btn {
+        color: #6c757d;
+        background: white;
+        font-weight: bold;
+        border: 1px solid white;
+        margin-right: 5px !important;
+      }
+    }
+
+    &__row-header-options--fixed{
+      // fixed
+      position: fixed;
+      right: 0;
+      z-index: 1030;
+      top: 70px;
+      width: 100%;
+
+      @include for-tablet-landscape-up{
+        left: 280px;
+      }
+
+      @include for-tablet-landscape-bottom{
+        margin: 0px;
+        top: 58px;
+        padding: 5px 0px;
+      }
+    }
+
+    &--space-for-questionyear{
+      padding-top: 25px;
+    }
+
+    &--space-for-titlequestion{
+      padding-top: 35px;
     }
 
     &__col-full-section-details{
@@ -120,7 +157,7 @@
 
     &__btn-remove-question{
       background: $color-ma-red !important;
-      color: $color-ma-white;
+      color: $color-ma-white !important;
       border: 1px solid  $color-ma-red !important;
     }
 

--- a/src/assets/scss/styles.scss
+++ b/src/assets/scss/styles.scss
@@ -22,6 +22,7 @@
 //Components related to Navigation
 @import 'components/navigation/Sidebar';
 @import 'components/navigation/Menu';
+@import 'components/navigation/MenuQuestionToolbar';
 
 //Components related to Star Rating
 @import 'components/stars/Star';

--- a/src/components/question/BackUsingHistory.js
+++ b/src/components/question/BackUsingHistory.js
@@ -3,13 +3,13 @@ import { history } from 'helpers/history';
 import { Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-const BackUsingHistory = location => (
+const BackUsingHistory = (location = true) => (
   location
     ? (
       <Button onClick={history.goBack} className="mr-auto btn btn-secondary c-question__btn-back">
         <FontAwesomeIcon icon="arrow-circle-left" className="btn__icon" />
         {' '}
-        Voltar History
+        Voltar
       </Button>
     ) : (
       <Button onClick={() => history.push('/question-base/1')} className="mr-auto btn btn-secondary c-question__btn-back">

--- a/src/pages/Question/CreateQuestionPage.js
+++ b/src/pages/Question/CreateQuestionPage.js
@@ -461,8 +461,8 @@ class CreateQuestionPage extends Component {
       <HomeUserPage>
         <Form onSubmit={handleSubmit}>
           <div className="c-question c-create-question">
-            <Row className="c-question__row-header-options">
-              <Col className="d-flex justify-content-end">
+            <Row className="c-question__row-header-options c-question__row-header-options--fixed">
+              <Col /*className="d-flex justify-content-end"*/>
                 <Button className="btn btn-secondary c-question__btn-back" to="/edit-question/" type="submit">
                   <FontAwesomeIcon
                     className="btn__icon"
@@ -473,7 +473,7 @@ class CreateQuestionPage extends Component {
                 </Button>
               </Col>
             </Row>
-            <Row className="c-question__tittle-section">
+            <Row className="c-question__tittle-section c-question--space-for-titlequestion">
               <Col>
                 <h4>
                   <FontAwesomeIcon icon="book" />

--- a/src/pages/Question/CreateQuestionPage.js
+++ b/src/pages/Question/CreateQuestionPage.js
@@ -17,6 +17,7 @@ import { Field, FieldArray } from 'redux-form';
 import { getTeachingLevel } from 'helpers/question';
 import Multiselect from 'react-widgets/lib/Multiselect';
 import Back from 'components/question/Back';
+import BackUsingHistory from 'components/question/BackUsingHistory';
 
 const difficultyList = {
   difficulties: [
@@ -464,7 +465,7 @@ class CreateQuestionPage extends Component {
           <div className="c-question c-create-question">
             <Row className="c-question__row-header-options c-question__row-header-options--fixed">
               <Col /*className="d-flex justify-content-end"*/>
-                <Back />
+                <BackUsingHistory />
                 <Button className="btn btn-secondary c-question__btn-back" to="/edit-question/" type="submit">
                   <FontAwesomeIcon
                     className="btn__icon"

--- a/src/pages/Question/CreateQuestionPage.js
+++ b/src/pages/Question/CreateQuestionPage.js
@@ -16,6 +16,7 @@ import {
 import { Field, FieldArray } from 'redux-form';
 import { getTeachingLevel } from 'helpers/question';
 import Multiselect from 'react-widgets/lib/Multiselect';
+import Back from 'components/question/Back';
 
 const difficultyList = {
   difficulties: [
@@ -463,6 +464,7 @@ class CreateQuestionPage extends Component {
           <div className="c-question c-create-question">
             <Row className="c-question__row-header-options c-question__row-header-options--fixed">
               <Col /*className="d-flex justify-content-end"*/>
+                <Back />
                 <Button className="btn btn-secondary c-question__btn-back" to="/edit-question/" type="submit">
                   <FontAwesomeIcon
                     className="btn__icon"

--- a/src/pages/Question/MyQuestionEditPage.js
+++ b/src/pages/Question/MyQuestionEditPage.js
@@ -8,6 +8,7 @@ import QuestionTextRichEditor from 'components/textricheditor/QuestionTextRichEd
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 import MAMultiSelectTag from 'components/tags/MAMultiSelectTag';
 import DeleteQuestionButtonContainer from 'containers/DeleteQuestionButtonContainer';
+import Back from 'components/question/Back';
 
 import {
   requiredValidator,
@@ -494,8 +495,9 @@ class MyQuestionEditPage extends Component {
         <HomeUserPage>
           <Form onSubmit={handleSubmit}>
             <div className="c-question c-create-question">
-              <Row className="c-question__row-header-options">
-                <Col className="d-flex justify-content-end">
+              <Row className="c-question__row-header-options c-question__row-header-options--fixed">
+                <Col /*className="d-flex justify-content-end"*/>
+                  <Back />
                   <DeleteQuestionButtonContainer
                     questionId={activeQuestion.id}
                     customClass="c-question__btn-remove-question btn__icon"
@@ -521,7 +523,7 @@ class MyQuestionEditPage extends Component {
                   </Button>
                 </Col>
               </Row>
-              <Row className="c-question__tittle-section">
+              <Row className="c-question__tittle-section c-question--space-for-titlequestion">
                 <Col>
                   <h4>
                     <FontAwesomeIcon icon="book" />

--- a/src/pages/Question/MyQuestionEditPage.js
+++ b/src/pages/Question/MyQuestionEditPage.js
@@ -9,6 +9,8 @@ import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 import MAMultiSelectTag from 'components/tags/MAMultiSelectTag';
 import DeleteQuestionButtonContainer from 'containers/DeleteQuestionButtonContainer';
 import Back from 'components/question/Back';
+import BackUsingHistory from 'components/question/BackUsingHistory';
+
 
 import {
   requiredValidator,
@@ -497,7 +499,7 @@ class MyQuestionEditPage extends Component {
             <div className="c-question c-create-question">
               <Row className="c-question__row-header-options c-question__row-header-options--fixed">
                 <Col /*className="d-flex justify-content-end"*/>
-                  <Back />
+                  <BackUsingHistory />
                   <DeleteQuestionButtonContainer
                     questionId={activeQuestion.id}
                     customClass="c-question__btn-remove-question btn__icon"

--- a/src/pages/Question/QuestionEditPage.js
+++ b/src/pages/Question/QuestionEditPage.js
@@ -334,8 +334,8 @@ class QuestionEditPage extends Component {
       <HomeUserPage>
         <Form onSubmit={handleSubmit}>
           <div className="c-question">
-            <Row className="c-question__row-header-options">
-              <Col className="d-flex">
+            <Row className="c-question__row-header-options c-question__row-header-options--fixed">
+              <Col /*className="d-flex"*/>
                 <Button
                   onClick={() => history.replace(`/view-question/${activeQuestion.id}`)}
                   className="mr-auto btn btn-secondary c-question__btn-back"
@@ -364,7 +364,7 @@ class QuestionEditPage extends Component {
                 </Button>
               </Col>
             </Row>
-            <Row className="c-question__tittle-section">
+            <Row className="c-question__tittle-section c-question--space-for-titlequestion">
               <Col>
                 <h4>
                   <FontAwesomeIcon icon="book" />
@@ -385,7 +385,7 @@ class QuestionEditPage extends Component {
                 </Alert>
               </Col>
             </Row>
-            <Row className="c-question__options">
+            <Row className="c-question__options hidden">
               <Col className="d-flex  justify-content-end">
                 <span className="c-question__label-tag-header c-question__tag--purple p-2">
                   {activeQuestion.source}

--- a/src/pages/Question/QuestionEditPage.js
+++ b/src/pages/Question/QuestionEditPage.js
@@ -20,6 +20,8 @@ import { requiredSelectValidator, minLength2TagsForEdit, minLength1Topics } from
 // import MAReactTags from 'components/tags/MAReactTag';
 import { history } from 'helpers/history';
 import MAMultiSelectTag from 'components/tags/MAMultiSelectTag';
+import Back from 'components/question/Back';
+import BackUsingHistory from 'components/question/BackUsingHistory';
 
 const difficultyList = {
   difficulties: [
@@ -336,14 +338,7 @@ class QuestionEditPage extends Component {
           <div className="c-question">
             <Row className="c-question__row-header-options c-question__row-header-options--fixed">
               <Col /*className="d-flex"*/>
-                <Button
-                  onClick={() => history.replace(`/view-question/${activeQuestion.id}`)}
-                  className="mr-auto btn btn-secondary c-question__btn-back"
-                >
-                  <FontAwesomeIcon icon="arrow-circle-left" className="btn__icon" />
-                  {' '}
-                Voltar
-                </Button>
+                <BackUsingHistory />
                 <Link className="btn btn-secondary c-question__btn-back btn__icon hidden" to={`/view-question/${activeQuestion.id}`} role="button">
                   <FontAwesomeIcon icon="eye" className="btn__icon" />
                   {' '}

--- a/src/pages/Question/QuestionPage.js
+++ b/src/pages/Question/QuestionPage.js
@@ -119,8 +119,8 @@ class QuestionPage extends Component {
     return (
       <HomeUserPage>
         <div className="c-question">
-          <Row className="c-question__row-header-options">
-            <Col className="d-flex">
+          <Row className="c-question__row-header-options c-question__row-header-options--fixed">
+            <Col /*className="d-flex"*/>
               <Back />
               { (isOwner && !activeQuestion.disabled)
                 ? (
@@ -149,7 +149,7 @@ class QuestionPage extends Component {
                 ) : ''}
             </Col>
           </Row>
-          <Row className="c-question__options">
+          <Row className="c-question__options c-question--space-for-questionyear">
             <Col className="d-flex  justify-content-end">
               <span className="c-question__label-tag-header c-question__tag--purple p-2">
                 {activeQuestion.source}

--- a/src/pages/Question/QuestionPage.js
+++ b/src/pages/Question/QuestionPage.js
@@ -12,6 +12,8 @@ import HomeUserPage from 'pages/HomeUser/HomeUserPage';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Link } from 'react-router-dom';
 import Back from 'components/question/Back';
+import BackUsingHistory from 'components/question/BackUsingHistory';
+
 import { history } from 'helpers/history';
 
 
@@ -121,7 +123,7 @@ class QuestionPage extends Component {
         <div className="c-question">
           <Row className="c-question__row-header-options c-question__row-header-options--fixed">
             <Col /*className="d-flex"*/>
-              <Back />
+              <BackUsingHistory />
               { (isOwner && !activeQuestion.disabled)
                 ? (
                   <DeleteQuestionButtonContainer


### PR DESCRIPTION
- Toolbar fixed in 'CreateQuestion', 'ViewQuestion', 'Classify Question' and 'Edit Question'. Test in web and mobile mode.
- According our planning discussion: Back button is shown in Create, View, Edit and Classify Question and it is working as browser'back button doing. However, is pending to solve this bug: "open new tab, enter to url i.e. /view-question/{id}, clic on back, a white screen is shown, it will be solved in other branch.