### PR TITLE
css 100%width

### DIFF
--- a/src/assets/scss/components/modal/_Modal.scss
+++ b/src/assets/scss/components/modal/_Modal.scss
@@ -142,6 +142,7 @@
   overflow: auto;
   outline: 0;
   padding: 5px;
+  width: 100%;
 }
 
 .modal-fixed__footer{

--- a/src/components/modal/SearchLearningObjectModal.js
+++ b/src/components/modal/SearchLearningObjectModal.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Button, Row, Col, Alert } from 'reactstrap';
+import {
+  Button, Row, Col, Alert,
+} from 'reactstrap';
 import PropTypes from 'prop-types';
 
 import CustomPaginationModal from 'components/pagination/CustomPaginationModal';
@@ -62,16 +64,16 @@ class SearchLearningObjectModal extends React.Component {
               <CustomPaginationModal {...this.props} {...objectPage} itensPerPage={16} disabled={isFetching} />
             </Row>
             <Row>
-      <Col sm="12" className="c-object-base__total-results">
-        {`Objetos de aprendizagem encontrados:`}
-        {objectPage ? objectPage.count : 0}
-      </Col>
-        <Col sm="12" className="c-object-base-modal__selected-number">
-          Objetos associados à questão:
-          {' '}
-          {selectedObjectList.length}
-        </Col>
-      </Row>
+              <Col sm="12" className="c-object-base__total-results">
+                {'Objetos de aprendizagem encontrados:'}
+                {objectPage ? objectPage.count : 0}
+              </Col>
+              <Col sm="12" className="c-object-base-modal__selected-number">
+                Objetos associados à questão:
+                {' '}
+                {selectedObjectList.length}
+              </Col>
+            </Row>
             <div className="c-question-base__results modal-fixed__body-section-scroll">
               { isFetching ? (
                 <Alert className="c-question-base__alert--warning" color="warning" fade={false}>


### PR DESCRIPTION
- Fix: if object search in modal has less than 4 results, they are shown correctly.
Currently: If there are less than 4 results, layout is broken